### PR TITLE
Accept ssh args other than default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ target/
 *.gz
 *.zip
 .eggs
+
+.vscode/
+.venv/


### PR DESCRIPTION
In some use cases, additional ssh options are required for the
``ssh`` command, for instance, ``ProxyCommand`` or such.

Using ``--ssh-args`` argument to ``docker-ssh`` it is now
possible to pass comma-separated options to ``ssh`` command.

Example:

```
docker-ssh --ssh-args '-o,ExitOnForwardFailure=yes,-T,-i my_identity.pem,-o,StrictHostKeyChecking=no' myhost docker ps
```